### PR TITLE
Upstream Expanded on API for Checkbox and for Enabled. (#447)

### DIFF
--- a/cursive-core/src/views/checkbox.rs
+++ b/cursive-core/src/views/checkbox.rs
@@ -119,6 +119,15 @@ impl Checkbox {
         }
     }
 
+    /// Set the checkbox state.
+    ///
+    /// Chainable variant.
+    pub fn with_checked(self, is_checked: bool) -> Self {
+        self.with(|s| {
+            s.set_checked(is_checked);
+        })
+    }
+
     fn draw_internal(&self, printer: &Printer<'_, '_>) {
         printer.print((0, 0), "[ ]");
         if self.checked {

--- a/cursive-core/src/views/mod.rs
+++ b/cursive-core/src/views/mod.rs
@@ -44,6 +44,14 @@ macro_rules! impl_enabled {
             self.$x = enabled;
         }
 
+        /// Enable or disable this view.
+        ///
+        /// Chainable variant.
+        pub fn with_enabled(mut self, is_enabled: bool) -> Self {
+            self.set_enabled(is_enabled);
+            self
+        }
+
         /// Returns `true` if this view is enabled.
         pub fn is_enabled(&self) -> bool {
             self.$x


### PR DESCRIPTION
Added a `with_x` variant to both, for easier chaining.